### PR TITLE
INTERLOK-3550 Removed components that are Deprecated for 3.12.0 

### DIFF
--- a/src/main/java/com/adaptris/hpcc/SprayDirectoryToThor.java
+++ b/src/main/java/com/adaptris/hpcc/SprayDirectoryToThor.java
@@ -76,6 +76,7 @@ public class SprayDirectoryToThor extends SprayToThorImpl {
   @Getter
   @Setter
   private String prefix;
+  
   /**
    * The source directory to spray into Thor.
    *
@@ -84,16 +85,7 @@ public class SprayDirectoryToThor extends SprayToThorImpl {
   @Setter
   @InputFieldHint(expression = true)
   private String sourceDirectory;
-  /**
-   * Set the metadata containing the source directory to upload.
-   *
-   * @deprecated since 3.6.6 use {@link #setSourceDirectory(String)} instead.
-   */
-  @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use 'source-directory' instead", groups = Deprecated.class)
-  @Getter
-  @Setter
-  private String sourceDirectoryKey;
+
   /**
    * Specify true to delete the source directory after successfully spray into HPCC.
    * <p>
@@ -139,15 +131,7 @@ public class SprayDirectoryToThor extends SprayToThorImpl {
   }
 
   private File getSourceDir(AdaptrisMessage msg) throws Exception {
-    File dir = null;
-    if (!isBlank(getSourceDirectoryKey())) {
-      log.warn("source-directory-key is deprecated; use source-directory instead");
-      dir = new File(msg.getMetadataValue(getSourceDirectoryKey()));
-    }
-    else {
-      dir = new File(msg.resolve(getSourceDirectory()));
-    }
-    return dir;
+    return new File(msg.resolve(getSourceDirectory()));
   }
 
   private void postSprayCleanup(AdaptrisMessage msg) throws Exception {

--- a/src/main/java/com/adaptris/hpcc/SprayDirectoryToThor.java
+++ b/src/main/java/com/adaptris/hpcc/SprayDirectoryToThor.java
@@ -130,7 +130,7 @@ public class SprayDirectoryToThor extends SprayToThorImpl {
     return result;
   }
 
-  private File getSourceDir(AdaptrisMessage msg) throws Exception {
+  public File getSourceDir(AdaptrisMessage msg) throws Exception {
     return new File(msg.resolve(getSourceDirectory()));
   }
 

--- a/src/main/java/com/adaptris/hpcc/SprayToThor.java
+++ b/src/main/java/com/adaptris/hpcc/SprayToThor.java
@@ -29,6 +29,7 @@ import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.lms.FileBackedMessage;
 import com.adaptris.core.util.ExceptionHelper;
+import com.adaptris.hpcc.arguments.FixedSprayFormat;
 import com.adaptris.hpcc.arguments.SprayFormat;
 import com.thoughtworks.xstream.annotations.XStreamAlias;
 
@@ -52,7 +53,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 public class SprayToThor extends SprayToThorImpl {
 
   @NotNull
-  private SprayFormat sprayFormat;
+  private SprayFormat sprayFormat = new FixedSprayFormat(125);
 
   @AdvancedConfig
   private String tempDirectory;

--- a/src/main/java/com/adaptris/hpcc/SprayToThor.java
+++ b/src/main/java/com/adaptris/hpcc/SprayToThor.java
@@ -17,6 +17,7 @@ package com.adaptris.hpcc;
 
 import java.io.File;
 import java.io.IOException;
+import javax.validation.constraints.NotNull;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileUtils;
@@ -50,6 +51,7 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @DisplayOrder(order = {"logicalFilename", "cluster", "sprayFormat", "overwrite", "tempDirectory"})
 public class SprayToThor extends SprayToThorImpl {
 
+  @NotNull
   private SprayFormat sprayFormat;
 
   @AdvancedConfig
@@ -74,11 +76,7 @@ public class SprayToThor extends SprayToThorImpl {
   }
 
   void addFormatArguments(CommandLine commandLine){
-    if(getSprayFormat() == null) {
-      log.warn("spray-format is null");
-    } else {
-      getSprayFormat().addArguments(commandLine);
-    }
+    getSprayFormat().addArguments(commandLine);
   }
 
   public SprayFormat getSprayFormat() {

--- a/src/main/java/com/adaptris/hpcc/SprayToThor.java
+++ b/src/main/java/com/adaptris/hpcc/SprayToThor.java
@@ -24,8 +24,6 @@ import com.adaptris.annotation.AdapterComponent;
 import com.adaptris.annotation.AdvancedConfig;
 import com.adaptris.annotation.ComponentProfile;
 import com.adaptris.annotation.DisplayOrder;
-import com.adaptris.validation.constraints.ConfigDeprecated;
-import com.adaptris.annotation.Removal;
 import com.adaptris.core.AdaptrisMessage;
 import com.adaptris.core.ProduceException;
 import com.adaptris.core.lms.FileBackedMessage;
@@ -52,20 +50,10 @@ import com.thoughtworks.xstream.annotations.XStreamAlias;
 @DisplayOrder(order = {"logicalFilename", "cluster", "sprayFormat", "overwrite", "tempDirectory"})
 public class SprayToThor extends SprayToThorImpl {
 
-  @Deprecated
-  public enum FORMAT { CSV, FIXED; }
-
   private SprayFormat sprayFormat;
 
   @AdvancedConfig
   private String tempDirectory;
-
-  @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use 'spray-format' instead", groups = Deprecated.class)
-  private FORMAT format;
-  @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use 'spray-format' instead", groups = Deprecated.class)
-  private Integer maxRecordSize;
 
   private transient final FileCleaningTracker tracker = new FileCleaningTracker();
 
@@ -87,53 +75,10 @@ public class SprayToThor extends SprayToThorImpl {
 
   void addFormatArguments(CommandLine commandLine){
     if(getSprayFormat() == null) {
-      log.warn("Use spray-format instead");
-      commandLine.addArgument(String.format("format=%s", getFormat().name().toLowerCase()));
-      commandLine.addArgument(String.format("maxrecordsize=%d", maxRecordSize()));
+      log.warn("spray-format is null");
     } else {
       getSprayFormat().addArguments(commandLine);
     }
-  }
-
-  /**
-   * @deprecated since 3.7 use {@link #getSprayFormat()} instead.
-   */
-  @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use 'spray-format' instead", groups = Deprecated.class)
-  public FORMAT getFormat() {
-    return format;
-  }
-
-  /**
-   * @deprecated since 3.7 use {@link #setSprayFormat(SprayFormat)} instead.
-   */
-  @Deprecated
-  @Removal(version = "3.12.0", message = "use 'spray-format' instead")
-  public void setFormat(FORMAT format) {
-    this.format = format;
-  }
-
-  /**
-   * @deprecated since 3.7 use {@link #getSprayFormat()} instead.
-   */
-  @Deprecated
-  @ConfigDeprecated(removalVersion = "3.12.0", message = "use 'spray-format' instead", groups = Deprecated.class)
-  public Integer getMaxRecordSize() {
-    return maxRecordSize;
-  }
-
-  /**
-   * @deprecated since 3.7 use {@link #setSprayFormat(SprayFormat)} instead.
-   */
-  @Deprecated
-  @Removal(version = "3.12.0", message = "use 'spray-format' instead")
-  public void setMaxRecordSize(Integer maxRecordSize) {
-    this.maxRecordSize = maxRecordSize;
-  }
-
-  @Deprecated
-  private int maxRecordSize() {
-    return getMaxRecordSize() != null ? getMaxRecordSize() : 8192;
   }
 
   public SprayFormat getSprayFormat() {

--- a/src/test/java/com/adaptris/hpcc/SprayDirectoryToThorTest.java
+++ b/src/test/java/com/adaptris/hpcc/SprayDirectoryToThorTest.java
@@ -15,6 +15,11 @@
 */
 package com.adaptris.hpcc;
 
+import static org.junit.Assert.assertNotNull;
+import java.io.File;
+import org.junit.Test;
+import com.adaptris.core.AdaptrisMessage;
+import com.adaptris.core.AdaptrisMessageFactory;
 import com.adaptris.core.ProducerCase;
 import com.adaptris.core.StandaloneProducer;
 
@@ -40,5 +45,17 @@ public class SprayDirectoryToThorTest extends ProducerCase {
     p.setPrefix("FILENAME,FILESIZE");
     p.setSourceDirectory("%message{metadataKeyContainingDirectory}");
     return new StandaloneProducer(c, p);
+  }
+  
+  @Test
+  public void testGetSourceDir() throws Exception {
+    SprayDirectoryToThor p = new SprayDirectoryToThor();
+    p.setSourceDirectory("metadataKeyContainingDirectory");
+
+    AdaptrisMessage msg = AdaptrisMessageFactory.getDefaultInstance().newMessage();
+    msg.addMetadata("metadataKeyContainingDirectory", "test");
+
+    File f = p.getSourceDir(msg);
+    assertNotNull(f);
   }
 }

--- a/src/test/java/com/adaptris/hpcc/SprayToThorTest.java
+++ b/src/test/java/com/adaptris/hpcc/SprayToThorTest.java
@@ -31,60 +31,6 @@ public class SprayToThorTest extends ProducerCase {
   }
 
   @Test
-  public void testLegacyCsvFormat() throws Exception {
-    SprayToThor sprayToThor = new SprayToThor();
-    sprayToThor.setFormat(SprayToThor.FORMAT.CSV);
-    CommandLine cmdLine = new CommandLine("/bin/dfuplus");
-    sprayToThor.addFormatArguments(cmdLine);
-    assertEquals(2, cmdLine.getArguments().length);
-    assertEquals("format=csv", cmdLine.getArguments()[0]);
-    assertEquals("maxrecordsize=8192", cmdLine.getArguments()[1]);
-  }
-
-  @Test
-  public void testLegacyCsvFormatMaxRecordSize() throws Exception {
-    SprayToThor sprayToThor = new SprayToThor();
-    sprayToThor.setFormat(SprayToThor.FORMAT.CSV);
-    sprayToThor.setMaxRecordSize(214);
-    CommandLine cmdLine = new CommandLine("/bin/dfuplus");
-    sprayToThor.addFormatArguments(cmdLine);
-    assertEquals(2, cmdLine.getArguments().length);
-    assertEquals("format=csv", cmdLine.getArguments()[0]);
-    assertEquals("maxrecordsize=214", cmdLine.getArguments()[1]);
-  }
-
-  /**
-   * Technically this won't work with dfuplus as it doesn't set <code>recordsize</code>.
-   * @throws Exception
-   */
-  @Test
-  public void testLegacyFixedFormat() throws Exception {
-    SprayToThor sprayToThor = new SprayToThor();
-    sprayToThor.setFormat(SprayToThor.FORMAT.FIXED);
-    CommandLine cmdLine = new CommandLine("/bin/dfuplus");
-    sprayToThor.addFormatArguments(cmdLine);
-    assertEquals(2, cmdLine.getArguments().length);
-    assertEquals("format=fixed", cmdLine.getArguments()[0]);
-    assertEquals("maxrecordsize=8192", cmdLine.getArguments()[1]);
-  }
-
-  /**
-   * Technically this won't work with dfuplus as it doesn't set <code>recordsize</code>.
-   * @throws Exception
-   */
-  @Test
-  public void testLegacyFixedFormatMaxRecordSize() throws Exception {
-    SprayToThor sprayToThor = new SprayToThor();
-    sprayToThor.setFormat(SprayToThor.FORMAT.FIXED);
-    sprayToThor.setMaxRecordSize(214);
-    CommandLine cmdLine = new CommandLine("/bin/dfuplus");
-    sprayToThor.addFormatArguments(cmdLine);
-    assertEquals(2, cmdLine.getArguments().length);
-    assertEquals("format=fixed", cmdLine.getArguments()[0]);
-    assertEquals("maxrecordsize=214", cmdLine.getArguments()[1]);
-  }
-
-  @Test
   public void testCSVFormat() throws Exception {
     SprayToThor sprayToThor = new SprayToThor();
     sprayToThor.setSprayFormat(new CSVSprayFormat());


### PR DESCRIPTION
## Motivation

Components were marked for removal for the 3.12 release

## Modification

- removed enum FORMAT, FORMAT format, Integer maxRecordSize from SprayToThor
- updated addFormatArguments to removed legacy stuff from SprayToThor
- removed testLegacy* tests in SprayToThorTest 
- removed sourceDirectoryKey from SprayDirectoryToThor

## Result

Tests all pass, and no more deprecated items present.

## Testing

eye ball code, run tests.
