### PR TITLE
INTERLOK-4461: Use FsHelper.toFile()

### DIFF
--- a/src/main/java/com/adaptris/hpcc/DesprayFromThor.java
+++ b/src/main/java/com/adaptris/hpcc/DesprayFromThor.java
@@ -21,6 +21,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.InetAddress;
+import java.net.URISyntaxException;
+
+import com.adaptris.core.fs.FsHelper;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.IOUtils;
@@ -99,10 +102,10 @@ public class DesprayFromThor extends SingleFileRequest {
   }
 
 
-  private File createAndTrackFile(Object marker) throws IOException {
+  private File createAndTrackFile(Object marker) throws IOException, URISyntaxException {
     File result = null;
     if (getTempDirectory() != null) {
-      result = File.createTempFile(this.getClass().getSimpleName(), "", new File(getTempDirectory()));
+        result = File.createTempFile(this.getClass().getSimpleName(), "", FsHelper.toFile(getTempDirectory(), new File(getTempDirectory())));
     } else {
       result = File.createTempFile(this.getClass().getSimpleName(), "");
     }

--- a/src/main/java/com/adaptris/hpcc/SprayToThor.java
+++ b/src/main/java/com/adaptris/hpcc/SprayToThor.java
@@ -17,7 +17,10 @@ package com.adaptris.hpcc;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
 import javax.validation.constraints.NotNull;
+
+import com.adaptris.core.fs.FsHelper;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.io.FileCleaningTracker;
 import org.apache.commons.io.FileUtils;
@@ -123,7 +126,7 @@ public class SprayToThor extends SprayToThorImpl {
       // If the message is not file-backed, write it to a temp file
       try {
         if (getTempDirectory() != null) {
-          result = File.createTempFile("adp", ".dat", new File(getTempDirectory()));
+            result = File.createTempFile("adp", ".dat", FsHelper.toFile(getTempDirectory(), new File(getTempDirectory())));
         } else {
           result = File.createTempFile("adp", ".dat");
         }


### PR DESCRIPTION
## Motivation

Why am I doing this

## Modification

What did I change

## PR Checklist

- [x] been self-reviewed.
- [ ] Added javadocs for most classes and all non-trivial methods
- [ ] Added supporting annotations (like @XStreamAlias / @ComponentProfile)
- [ ] Added DefaultValue annotation when there is a default value (e.g. @DefaultValue('true'))
- [ ] Added validation annotation (@NotNull...) when required and add @Valid when nested class has some validation
- [ ] Checked that @NotNull and @NotBlank annotations have a meaningful message when appropriate.
- [ ] Checked that new 3rd party dependencies are appropriately licensed
- [ ] Added comments explaining the "why" and the intent of the code wherever it would not be obvious for an unfamiliar reader
- [ ] Added unit tests or modified existing tests to cover new code paths
- [ ] Tested new/updated components in the UI and at runtime in an Interlok instance
- [ ] Reviewed java class members so that missing annotations are added (InputFieldDefault/ComponentProfile etc)
- [ ] Checked that javadoc generation doesn't report errors
- [ ] Checked the display of the component in the UI
- [ ] Remove any config/license annotations
- [ ] Check the gradle build file to make sure the dependencies section is more explicit "implementation/api".

## Result

What's the end result for the user

## Testing

How can I test this if I'm reviewing this.
